### PR TITLE
Actualización del proceso de crear máquinas virtuales

### DIFF
--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72970.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72970.json
@@ -6,7 +6,7 @@
     "soHost":  "Microsoft Windows 10 Pro",
     "hostnameHost":  "Admin",
     "ramHost":  32438,
-    "cpuHost":  16,
+    "cpuHost":  16, 
     "almaceHost":  397,
     "sshHost":  "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/Samples/virtualMachine.txt
+++ b/servidor_procesamiento/Procesador/Samples/virtualMachine.txt
@@ -9,7 +9,7 @@ POST -> :8081/api/v1/virtual_machine
         "vm_ram": 2000,
         "vm_cpu": 2,
         "vm_usr_email": "admin@uqcloud.co",
-        "vm_host_id": 16
+        "vm_hostname":  "prueba pc casa"
     },
     "clientIP" : "192.168.1.6"
 }

--- a/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
+++ b/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
@@ -120,3 +120,13 @@ func PreregisterHostJsonData() {
 		}
 	}
 }
+
+/*
+Función que dado el nombre de un host retorna el objeto
+*/
+
+func GetHostIdByName(name string) (models.Host, error) {
+	var host models.Host
+	err := database.DATABASE.Where("nombre = ?", name).First(&host).Error
+	return host, err
+}

--- a/servidor_procesamiento/Procesador/main.go
+++ b/servidor_procesamiento/Procesador/main.go
@@ -155,7 +155,7 @@ func manageServer(r *mux.Router) {
 	r.HandleFunc(apiPrefix+"virtual_machine", handlers.ModifyVirtualMachineHandler).Methods("PUT")
 
 	//End point para eliminar màquinas virtuales
-	r.HandleFunc(apiPrefix+"virtual_machine", handlers.DeleteVirtualMachineHandler).Methods("DELETE")
+	r.HandleFunc(apiPrefix+"virtual_machine/{name}", handlers.DeleteVirtualMachineHandler).Methods("DELETE")
 
 	//End point para encender màquinas virtuales
 	r.HandleFunc(apiPrefix+"start_virtual_machine", handlers.StartVirtualMachineHandler).Methods("POST")


### PR DESCRIPTION
Anteriormente se usaba el id del host para indicar en donde se debía crear la máquina virtual, se realizó el cambio donde ahora se envía el nombre del host para indicar el mismo proceso. Esto facilita el serverside rendering a la hora de procesar las peticiones.