### PR TITLE
Simplificación arranque servidor de procesamiento y arreglo reglas de la base de datos

### DIFF
--- a/servidor_procesamiento/Procesador/Database/userQueries.go
+++ b/servidor_procesamiento/Procesador/Database/userQueries.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	_ "database/sql"
+	"fmt"
 	"log"
 	models "servidor_procesamiento/Procesador/Models"
 
@@ -72,6 +73,22 @@ func CreateNewUser(persona models.Persona) bool {
 		return false
 	}
 	return true
+}
+
+// Funcion para precargar el usuario administrador
+func CreateAdmin() {
+	if !CountAdminsRegistered() {
+		persona := models.Persona{
+			Nombre:      "admin",
+			Apellido:    "admin",
+			Email:       "admin@uqcloud.co",
+			Contrasenia: "$2y$10$JGxWitiykfO83Ep8IBab/.3fn.H/DxMjAK8dFTQCPZyJ5EHqZtfji", // Dejar este hash bcrypt para la contraseña "admin"
+			Rol:         1,
+		}
+
+		DATABASE.Create(&persona)
+		fmt.Print("Usuario administrador creado\n")
+	}
 }
 
 /*

--- a/servidor_procesamiento/Procesador/Handlers/diskManagerHandler.go
+++ b/servidor_procesamiento/Procesador/Handlers/diskManagerHandler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	database "servidor_procesamiento/Procesador/Database"
 	models "servidor_procesamiento/Procesador/Models"
+	"strings"
 )
 
 /*
@@ -17,12 +18,16 @@ Clase encargada de contener los handlers que responden a las acciones sobre los 
 // para registrar en la base de datos un nuevo disco para maquina virtual
 func AddDiskHandler(w http.ResponseWriter, r *http.Request) {
 	var disco models.Disco
+	var rutaDisco string
 
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&disco); err != nil {
 		http.Error(w, "Error al decodificar JSON de especificaciones", http.StatusBadRequest)
 		return
 	}
+	rutaDisco = strings.ReplaceAll(disco.Ruta_ubicacion, "/", "\\")
+
+	disco.Ruta_ubicacion = rutaDisco
 
 	err := database.CreateDisck(disco)
 

--- a/servidor_procesamiento/Procesador/Models/databaseStructs.go
+++ b/servidor_procesamiento/Procesador/Models/databaseStructs.go
@@ -23,7 +23,7 @@ type Persona struct {
 	gorm.Model
 	Nombre      string `json:"usr_name"`
 	Apellido    string `json:"usr_surname"`
-	Email       string `json:"usr_email"`
+	Email       string `json:"usr_email" gorm:"unique"`
 	Contrasenia string `json:"usr_password"`
 	Rol         byte   `json:"usr_role"`
 }
@@ -46,18 +46,18 @@ Estructura de datos tipo JSOn que contiene los datos de una màquina virtual
 type Maquina_virtual struct {
 	gorm.Model
 	Uuid                           string    `json:"vm_uuid"`
-	Nombre                         string    `json:"vm_name"`
-	Ram                            int       `json:"vm_ram"`
-	Cpu                            int       `json:"vm_cpu"`
+	Nombre                         string    `json:"vm_name" gorm:"unique"`
+	Ram                            int       `json:"vm_ram" gorm:"not null"`
+	Cpu                            int       `json:"vm_cpu" gorm:"not null"`
 	Ip                             string    `json:"vm_ip"`
-	Estado                         string    `json:"vm_state"`
-	Hostname                       string    `json:"vm_hostname"`
-	Persona_email                  string    `json:"vm_usr_email"`
-	Host_id                        int       `json:"vm_host_id"`
-	Disco_id                       int       `json:"vm_disk_id"`
-	Sistema_operativo              string    `json:"vm_so"`
-	Distribucion_sistema_operativo string    `json:"vm_so_distro"`
-	Fecha_creacion                 time.Time `json:"vm_creation_date"`
+	Estado                         string    `json:"vm_state" gorm:"not null"`
+	Hostname                       string    `json:"vm_hostname" gorm:"not null"`
+	Persona_email                  string    `json:"vm_usr_email" gorm:"not null"`
+	Host_id                        int       `json:"vm_host_id" gorm:"not null"`
+	Disco_id                       int       `json:"vm_disk_id" gorm:"not null"`
+	Sistema_operativo              string    `json:"vm_so" gorm:"not null"`
+	Distribucion_sistema_operativo string    `json:"vm_so_distro" gorm:"not null"`
+	Fecha_creacion                 time.Time `json:"vm_creation_date" gorm:"not null"`
 }
 
 /*
@@ -82,21 +82,21 @@ Estructura de datos tipo JSON que contiene los campos de un host
 type Host struct {
 	gorm.Model
 	Id                             int    `json:"hst_id"`
-	Nombre                         string `json:"hst_name"`
-	Mac                            string `json:"hst_mac"`
-	Ip                             string `json:"hst_ip"`
-	Hostname                       string `json:"hst_hostname"`
-	Ram_total                      int    `json:"hst_ram"`
-	Cpu_total                      int    `json:"hst_cpu"`
-	Almacenamiento_total           int    `json:"hst_storage"`
+	Nombre                         string `json:"hst_name" gorm:"unique"`
+	Mac                            string `json:"hst_mac" gorm:"unique, not null"`
+	Ip                             string `json:"hst_ip" gorm:"unique, not null"`
+	Hostname                       string `json:"hst_hostname" gorm:"not null"`
+	Ram_total                      int    `json:"hst_ram" gorm:"not null"`
+	Cpu_total                      int    `json:"hst_cpu" gorm:"not null"`
+	Almacenamiento_total           int    `json:"hst_storage" gorm:"not null"`
 	Ram_usada                      int    `json:"hst_used_ram"`
 	Cpu_usada                      int    `json:"hst_used_cpu"`
 	Almacenamiento_usado           int    `json:"hst_used_storage"`
-	Adaptador_red                  string `json:"hst_network"`
-	Estado                         string `json:"hst_state"`
-	Ruta_llave_ssh_pub             string `json:"hst_sshroute"`
-	Sistema_operativo              string `json:"hst_so"`
-	Distribucion_sistema_operativo string `json:"hst_so_distro"`
+	Adaptador_red                  string `json:"hst_network" gorm:"not null"`
+	Estado                         string `json:"hst_state" gorm:"not null"`
+	Ruta_llave_ssh_pub             string `json:"hst_sshroute" gorm:"not null"`
+	Sistema_operativo              string `json:"hst_so" gorm:"not null"`
+	Distribucion_sistema_operativo string `json:"hst_so_distro" gorm:"not null"`
 }
 
 /*
@@ -111,12 +111,12 @@ Estructura de datos tipo JSON que contiene los campos para representar una MV de
 type Catalogo struct {
 	gorm.Model
 	Id                             int    `json:"cat_id"`
-	Nombre                         string `json:"cat_name"`
-	Ram                            int    `json:"cat_ram"`
-	Cpu                            int    `json:"cat_cpu"`
-	Sistema_operativo              string `json:"cat_so"`
-	Distribucion_sistema_operativo string `json:"cat_so_distro"`
-	Arquitectura                   int    `json:"cat_arch"`
+	Nombre                         string `json:"cat_name" gorm:"not null"`
+	Ram                            int    `json:"cat_ram" gorm:"not null"`
+	Cpu                            int    `json:"cat_cpu" gorm:"not null"`
+	Sistema_operativo              string `json:"cat_so" gorm:"not null"`
+	Distribucion_sistema_operativo string `json:"cat_so_distro" gorm:"not null"`
+	Arquitectura                   int    `json:"cat_arch" gorm:"not null"`
 }
 
 /*
@@ -132,12 +132,12 @@ Estructura de datos tipo JSON que representa la informaciòn de los discos que t
 type Disco struct {
 	gorm.Model
 	Id                             int    `json:"dsk_id"`
-	Nombre                         string `json:"dsk_name"`
-	Ruta_ubicacion                 string `json:"dsk_route"`
-	Sistema_operativo              string `json:"dsk_so"`
-	Distribucion_sistema_operativo string `json:"dsk_so_distro"`
-	Arquitectura                   int    `json:"dsk_arch"`
-	Host_id                        int    `json:"dsk_host_id"`
+	Nombre                         string `json:"dsk_name" gorm:"not null"`
+	Ruta_ubicacion                 string `json:"dsk_route" gorm:"not null"`
+	Sistema_operativo              string `json:"dsk_so" gorm:"not null"`
+	Distribucion_sistema_operativo string `json:"dsk_so_distro" gorm:"not null"`
+	Arquitectura                   int    `json:"dsk_arch" gorm:"not null"`
+	Host_id                        int    `json:"dsk_host_id" gorm:"not null"`
 }
 
 /*

--- a/servidor_procesamiento/Procesador/Samples/host.txt
+++ b/servidor_procesamiento/Procesador/Samples/host.txt
@@ -17,4 +17,4 @@ POST -> :8081/api/v1/host
     "hst_sshroute": "c:\\users\\andres\\.ssh\\id_rsa.pub",
     "hst_so" : "windows",
     "hst_so_distro": "64"
-}
+}aa

--- a/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
+++ b/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
@@ -125,7 +125,7 @@ func PreregisterHostJsonData() {
 Función que dado el nombre de un host retorna el objeto
 */
 
-func GetHostIdByName(name string) (models.Host, error) {
+func GetHostByName(name string) (models.Host, error) {
 	var host models.Host
 	err := database.DATABASE.Where("nombre = ?", name).First(&host).Error
 	return host, err

--- a/servidor_procesamiento/Procesador/main.go
+++ b/servidor_procesamiento/Procesador/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Variable que almacena la ruta de la llave privada ingresada por paametro cuando de ejecuta el programa
-var privateKeyPath = flag.String("key", "", "Ruta de la llave privada SSH")
+var privateKeyPath = flag.String("key", "./keys/id_rsa", "")
 var preregisteredHosts = flag.Bool("h", false, "")
 
 func main() {
@@ -36,8 +36,10 @@ func main() {
 
 	//Verifica que el paràmetro de la ruta de la llave privada no estè vacìo
 	if *privateKeyPath == "" {
-		fmt.Println("Debe ingresar la ruta de la llave privada SSH")
+		fmt.Println("Error al encontrar la llave privada externa especificada")
 		return
+	} else {
+		fmt.Println("Iniciando servidor con llave privada: ", *privateKeyPath)
 	}
 
 	// Verifica si se ingresò el paràmetro para precargar los hosts
@@ -89,26 +91,7 @@ func setDatabase() {
 		&models.CatalogoDisco{})
 
 	// Precarga del usuario administrador
-	createAdmin()
-
-	// Precarga de los datos hosts
-	//registerHostData()
-}
-
-// Funcion para precargar el usuario administrador
-func createAdmin() {
-	if !database.CountAdminsRegistered() {
-		persona := models.Persona{
-			Nombre:      "admin",
-			Apellido:    "admin",
-			Email:       "admin@uqcloud.co",
-			Contrasenia: "$2y$10$JGxWitiykfO83Ep8IBab/.3fn.H/DxMjAK8dFTQCPZyJ5EHqZtfji", // Dejar este hash bcrypt para la contraseña "admin"
-			Rol:         1,
-		}
-
-		database.DATABASE.Create(&persona)
-		fmt.Print("Usuario administrador creado\n")
-	}
+	database.CreateAdmin()
 }
 
 // Función para precargar los datos de los hosts de la sala B y C (No cambian)


### PR DESCRIPTION
Se simplificó el proceso de arrancar el servidor haciendo uso de las llaves que se encuentran en la carpeta keys por lo que ahora el este servidor se puede ejecutar con " go run . " adicionalmente se agregaron las restricciones sql sobre las entidades en la base de datos.