### PR TITLE
Reconfiguración de precarga de hosts y lógica de congruencia de VM en DB y los Hosts

### DIFF
--- a/servidor_procesamiento/Procesador/Database/virtualMachineQueries.go
+++ b/servidor_procesamiento/Procesador/Database/virtualMachineQueries.go
@@ -164,6 +164,15 @@ func ExistVirtualMachine(virtualMachineName string) (bool, error) {
 	return true, nil
 }
 
+func GetAllVirtualMachines() ([]models.Maquina_virtual, error) {
+	var maquinas []models.Maquina_virtual
+	err := DATABASE.Find(&maquinas).Error
+	if err != nil {
+		return nil, err
+	}
+	return maquinas, nil
+}
+
 /*
 Funciòn que permite obtener todas las màquinas virtuales creadas en la plataforma por los usuarios con rol invitado
 @return Retorna un arreglo con todas las màquinas encontradas

--- a/servidor_procesamiento/Procesador/DatosHostJson/IPINVALIDA-datosHost-72968.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/IPINVALIDA-datosHost-72968.json
@@ -1,5 +1,5 @@
 ﻿{
-    "nameHost":  "X",
+    "nameHost":  "72968",
     "ipHost":  "172.26.16.1",
     "macHost":  "00:15:5D:56:1E:27",
     "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72969.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72969.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.110",
-    "macHost":  "84:69:93:81:80:EF",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  399,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72969",
+    "hst_ip": "10.0.48.110",
+    "hst_mac": "84:69:93:81:80:EF",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 399,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72970.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72970.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.123",
-    "macHost":  "84:69:93:81:82:19",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16, 
-    "almaceHost":  397,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72970",
+    "hst_ip": "10.0.48.123",
+    "hst_mac": "84:69:93:81:82:19",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 397,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72971.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72971.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.106",
-    "macHost":  "84:69:93:81:81:AB",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72971",
+    "hst_ip": "10.0.48.106",
+    "hst_mac": "84:69:93:81:81:AB",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72972.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72972.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.67",
-    "macHost":  "84:69:93:81:81:FF",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72972",
+    "hst_ip": "10.0.48.67",
+    "hst_mac": "84:69:93:81:81:FF",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72973.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72973.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.185",
-    "macHost":  "7C:57:58:C9:4D:4A",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  396,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72973",
+    "hst_ip": "10.0.48.185",
+    "hst_mac": "7C:57:58:C9:4D:4A",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 396,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72974.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72974.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.117",
-    "macHost":  "84:69:93:81:81:77",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  397,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72974",
+    "hst_ip": "10.0.48.117",
+    "hst_mac": "84:69:93:81:81:77",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 397,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72975.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72975.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.112",
-    "macHost":  "84:69:93:80:FE:18",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  396,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72975",
+    "hst_ip": "10.0.48.112",
+    "hst_mac": "84:69:93:80:FE:18",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 396,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72977.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72977.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.100.131",
-    "macHost":  "C4:D0:E3:73:29:A4",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  397,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72977",
+    "hst_ip": "10.0.100.131",
+    "hst_mac": "C4:D0:E3:73:29:A4",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 397,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72978.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72978.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.130",
-    "macHost":  "84:69:93:81:80:E9",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  377,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72978",
+    "hst_ip": "10.0.48.130",
+    "hst_mac": "84:69:93:81:80:E9",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 377,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72979.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72979.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.108",
-    "macHost":  "84:69:93:81:81:E1",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72979",
+    "hst_ip": "10.0.48.108",
+    "hst_mac": "84:69:93:81:81:E1",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72980.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72980.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.103",
-    "macHost":  "84:69:93:81:80:DB",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72980",
+    "hst_ip": "10.0.48.103",
+    "hst_mac": "84:69:93:81:80:DB",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72982.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72982.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.102",
-    "macHost":  "84:69:93:81:82:06",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  397,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72982",
+    "hst_ip": "10.0.48.102",
+    "hst_mac": "84:69:93:81:82:06",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 397,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72983.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72983.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.63",
-    "macHost":  "84:69:93:81:81:A3",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72983",
+    "hst_ip": "10.0.48.63",
+    "hst_mac": "84:69:93:81:81:A3",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72984.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72984.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.66",
-    "macHost":  "84:69:93:81:81:C4",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  396,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72984",
+    "hst_ip": "10.0.48.66",
+    "hst_mac": "84:69:93:81:81:C4",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 396,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72985.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72985.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.68",
-    "macHost":  "84:69:93:81:80:C8",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72985",
+    "hst_ip": "10.0.48.68",
+    "hst_mac": "84:69:93:81:80:C8",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72986.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72986.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.104",
-    "macHost":  "84:69:93:81:81:D5",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  397,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72986",
+    "hst_ip": "10.0.48.104",
+    "hst_mac": "84:69:93:81:81:D5",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 397,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72987.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72987.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.119",
-    "macHost":  "84:69:93:81:81:B9",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72987",
+    "hst_ip": "10.0.48.119",
+    "hst_mac": "84:69:93:81:81:B9",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72988.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72988.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.116",
-    "macHost":  "84:69:93:81:7F:AB",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72988",
+    "hst_ip": "10.0.48.116",
+    "hst_mac": "84:69:93:81:7F:AB",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72990.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72990.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.48.107",
-    "macHost":  "84:69:93:81:81:FB",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  396,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72990",
+    "hst_ip": "10.0.48.107",
+    "hst_mac": "84:69:93:81:81:FB",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 396,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72991.json
+++ b/servidor_procesamiento/Procesador/DatosHostJson/datosHost-72991.json
@@ -1,12 +1,12 @@
-﻿{
-    "nameHost":  "X",
-    "ipHost":  "10.0.100.200",
-    "macHost":  "C4:D0:E3:74:4D:A7",
-    "adapHost":  "Intel(R) Ethernet Connection (17) I219-LM",
-    "soHost":  "Microsoft Windows 10 Pro",
-    "hostnameHost":  "Admin",
-    "ramHost":  32438,
-    "cpuHost":  16,
-    "almaceHost":  398,
-    "sshHost":  "C:\\Users\\Admin\\.ssh"
+{
+    "hst_name": "72991",
+    "hst_ip": "10.0.100.200",
+    "hst_mac": "C4:D0:E3:74:4D:A7",
+    "hst_network": "Intel(R) Ethernet Connection (17) I219-LM",
+    "hst_so": "Microsoft Windows 10 Pro",
+    "hst_hostname": "Admin",
+    "hst_ram": 32438,
+    "hst_cpu": 16,
+    "hst_storage": 398,
+    "hst_sshroute": "C:\\Users\\Admin\\.ssh"
 }

--- a/servidor_procesamiento/Procesador/Handlers/hostHandler.go
+++ b/servidor_procesamiento/Procesador/Handlers/hostHandler.go
@@ -54,7 +54,20 @@ func CheckHostHandler(w http.ResponseWriter, r *http.Request) {
 	/*En la base de datos los indices de los host empiezan desde el indice 1
 	si el valor es cero se utiliza para disparar el algoritmo aleatorio
 	*/
-	id := int(mv["Host_id"].(float64))
+
+	// Intenta obtener el valor de "host_id" como float64 (Ni idea de por que llega el host_id como float) y luego convertir a int
+	var id int
+	switch v := mv["host_id"].(type) {
+	case float64:
+		id = int(v)
+	case int:
+		id = v
+	default:
+		// Maneja el caso en que el valor no es float64 ni int (genera un panic)
+		log.Println("El valor de host_id es nil o no es un float64 ni un int: ", mv["host_id"])
+		id = -1 // Valor predeterminado en caso de error
+	}
+
 	switch {
 	case id == 0:
 		//Se encola la maquina virtual a crear

--- a/servidor_procesamiento/Procesador/Utilities/guestVirtualMachineUtilities.go
+++ b/servidor_procesamiento/Procesador/Utilities/guestVirtualMachineUtilities.go
@@ -24,7 +24,7 @@ Cuando se crea la cuenta e ingresa a la base de datos, se encarga de invocar la 
 */
 
 func CreateTempAccount(clientIP string, distribucionSO string) string {
-	
+
 	persona := models.Persona{
 		Nombre:   "Usuario",
 		Apellido: "Invitado",

--- a/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
+++ b/servidor_procesamiento/Procesador/Utilities/hostUtilities.go
@@ -3,8 +3,8 @@ package utilities
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	database "servidor_procesamiento/Procesador/Database"
 	models "servidor_procesamiento/Procesador/Models"
@@ -52,31 +52,6 @@ func PreregisterHostJsonData() {
 	// Ruta donde se encuentran los archivos JSON
 	jsonPath := "./DatosHostJson/"
 
-	//creación de un alias para los archivos json con la información de los host
-	type Alias models.Host
-
-	aux := &struct {
-		*Alias
-		Id                             int    `json:"id"`
-		Nombre                         string `json:"nameHost"`
-		Mac                            string `json:"macHost"`
-		Ip                             string `json:"ipHost"`
-		Hostname                       string `json:"hostnameHost"`
-		Ram_total                      int    `json:"ramHost"`
-		Cpu_total                      int    `json:"cpuHost"`
-		Almacenamiento_total           int    `json:"almaceHost"`
-		Ram_usada                      int    `json:"ramUsada"`
-		Cpu_usada                      int    `json:"cpuUsada"`
-		Almacenamiento_usado           int    `json:"almacenamientoUsado"`
-		Adaptador_red                  string `json:"adapHost"`
-		Estado                         string `json:"estadoHost"`
-		Ruta_llave_ssh_pub             string `json:"sshHost"`
-		Sistema_operativo              string `json:"soHost"`
-		Distribucion_sistema_operativo string `json:"distribucionSistemaOperativo"`
-	}{
-		Alias: (*Alias)(nil),
-	}
-
 	// Buscar todos los archivos JSON en la carpeta
 	files, err := filepath.Glob(filepath.Join(jsonPath, "datosHost-*.json"))
 	if err != nil {
@@ -93,7 +68,7 @@ func PreregisterHostJsonData() {
 	// Procesar cada archivo JSON
 	for _, file := range files {
 		// Leer el archivo JSON
-		data, err := os.ReadFile(file)
+		data, err := ioutil.ReadFile(file)
 		if err != nil {
 			log.Printf("Error al leer el archivo %s: %v", file, err)
 			continue
@@ -103,14 +78,12 @@ func PreregisterHostJsonData() {
 		data = bytes.TrimPrefix(data, []byte("\xef\xbb\xbf"))
 
 		// Deserializar el contenido del JSON en un struct Host
-		err = json.Unmarshal(data, aux)
+		var host models.Host
+		err = json.Unmarshal(data, &host)
 		if err != nil {
 			log.Printf("Error al deserializar el archivo %s: %v", file, err)
 			continue
 		}
-
-		// Extraer el Host deserializado desde el auxiliar
-		host := (*models.Host)(aux.Alias)
 
 		// Guardar el host en la base de datos usando GORM
 		if err := database.DATABASE.Create(&host).Error; err != nil {

--- a/servidor_procesamiento/Procesador/Utilities/virtualMachineUtilities.go
+++ b/servidor_procesamiento/Procesador/Utilities/virtualMachineUtilities.go
@@ -238,7 +238,7 @@ func UpdateVirtualMachinesActualStatus() {
 		return
 	}
 
-	log.Println("Maquinas virtuales en la base de datos: ", maquinas)
+	log.Println("Maquinas virtuales registradas la base de datos: ", maquinas)
 
 	/* Se comparan con las maquinas virtuales que estan realmente en los hosts utilizando VBoxManage remotamente
 	y se eliminan de la base de datos las maquinas virtuales que no estan realmente en los hosts*/

--- a/servidor_procesamiento/Procesador/main.go
+++ b/servidor_procesamiento/Procesador/main.go
@@ -94,6 +94,7 @@ func setDatabase() {
 	database.CreateAdmin()
 
 	// Actualizar las máquinas virtuales que estén disponibles realmente en los hosts
+	// Esto se hace para que haya congruencia entre la BD y las VM existentes realmente
 	utilities.UpdateVirtualMachinesActualStatus()
 }
 

--- a/servidor_procesamiento/Procesador/main.go
+++ b/servidor_procesamiento/Procesador/main.go
@@ -92,6 +92,9 @@ func setDatabase() {
 
 	// Precarga del usuario administrador
 	database.CreateAdmin()
+
+	// Actualizar las máquinas virtuales que estén disponibles realmente en los hosts
+	utilities.UpdateVirtualMachinesActualStatus()
 }
 
 // Función para precargar los datos de los hosts de la sala B y C (No cambian)

--- a/servidor_web/web/templates/createDisk.html
+++ b/servidor_web/web/templates/createDisk.html
@@ -77,7 +77,7 @@
                 </div>
 
                 <div class="col-md-6">
-                  <label for="inputRouteDisk" class="form-label">Ruta del disco</label>
+                  <label for="inputRouteDisk" class="form-label">Ruta del disco<br><span style="font-size: 10pt;">Ejemplo: "C:\uqcloud\Alpine.vdi"</span></label>
                   <input type="text" class="form-control" id="inputRouteDisk" placeholder="Ingresa la ruta donde esta el disco">
                 </div>
 


### PR DESCRIPTION
- Se actualizó la estructura de la precarga de los hosts con la nueva struct implementada (Por lo tanto ya no es necesaria la lógica de Alias implementada anteriormente)
- Se implementó una lógica que verifica en el despliegue del servidor de procesamiento si las VM registradas en la DB estan realmente disponibles en los Hosts indicados, si no, realiza un soft delete de estas.
- Se agregó la lógica para evitar un panic que puede ocurrir en la creación de un host